### PR TITLE
bump up version of wandb to adress API key length change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 
 dependencies = [
-  "wandb==0.19.8",
+  "wandb==0.24.0",
   "tqdm==4.67.1",
   "torchaudio>=2.6.0",
   "torch>=2.6.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-wandb==0.19.8
+wandb==0.24.0
 tqdm==4.67.1
 torchaudio==2.6.0
 torch==2.6.0


### PR DESCRIPTION
Weights & Biases now provide an 86 character api key. I had to bump the version to the latest one otherwise it does not accept the new key format.

I tested with the new version of `wandb` and the model still trains in my example.

Somewhat related issue seen in another repo:
https://github.com/huggingface/lerobot/issues/2762